### PR TITLE
chore(skills): add Flexprice docs writing and validation skill

### DIFF
--- a/.claude/skills/docs-writing/SKILL.md
+++ b/.claude/skills/docs-writing/SKILL.md
@@ -1,0 +1,334 @@
+---
+name: docs
+description: >
+  Write, extend, and validate Flexprice documentation pages in Mintlify MDX format.
+  Use this skill whenever the user asks to write a new doc, add a section to existing docs,
+  create a guide, document a feature, or update the Flexprice docs site.
+  Trigger when the user mentions "write a doc", "add docs", "documentation for", "create a guide",
+  "update the docs", "add to docs", "document this feature", "threshold notifications",
+  "alerts doc", or any request to produce or modify an .mdx file in the docs repo.
+  This skill knows the Mintlify MDX component set, the docs.json navigation schema,
+  the repo layout, the editorial voice, validation commands, and the dev server setup.
+---
+
+# Flexprice Docs — Writing and Validation Skill
+
+Write new documentation pages and validate them against the live Mintlify build. Always follow the existing style of the repo — read nearby docs before writing to match tone and component usage.
+
+---
+
+## Repo Layout
+
+```
+flexprice-docs/
+├── docs/                    ← All documentation pages (.mdx)
+│   ├── customers/           ← Customer-related docs
+│   ├── wallet/              ← Wallet docs
+│   ├── product-catalogue/   ← Plans, Features, Coupons
+│   ├── subscriptions/       ← Subscription workflows
+│   ├── webhook/             ← Webhook reference
+│   ├── event-ingestion/     ← Event & metering docs
+│   └── ...
+├── public/images/docs/      ← Screenshots referenced from docs
+├── docs.json                ← Navigation config (Mintlify v2)
+└── .claude/skills/          ← This skills directory
+```
+
+The docs site is at `https://docs.flexprice.io`. The `docs.json` at repo root controls all navigation.
+
+---
+
+## Step-by-Step: Writing a New Doc
+
+### 1. Read Before Writing
+
+Always read at least two nearby docs before writing — pick pages in the same section or covering similar topics. This ensures consistent tone, component choices, and structure.
+
+```bash
+# E.g. if writing a wallet doc:
+cat docs/wallet/auto-top-up.mdx
+cat docs/wallet/low-balance-alert.mdx
+```
+
+Also check `docs/webhook/webhooks.mdx` if the doc involves webhooks, and `docs/product-catalogue/features/wallet-balance-alert.mdx` for alert-related docs.
+
+### 2. Pick the Right File Location
+
+| Topic | Directory |
+|-------|-----------|
+| Customer management | `docs/customers/` |
+| Wallet features | `docs/wallet/` |
+| Plans, Features, Coupons | `docs/product-catalogue/` |
+| Subscription workflows | `docs/subscriptions/` |
+| Integrations | `integrations/<provider>/` |
+| Webhooks / events | `docs/webhook/` or `docs/event-ingestion/` |
+| Alerts & notifications | `docs/customers/` (customer-scoped) or nearest feature section |
+
+### 3. Frontmatter
+
+Every `.mdx` file starts with:
+
+```mdx
+---
+title: "Page Title"
+description: "One sentence describing what this page covers."
+---
+```
+
+- `title`: Short noun phrase, title case
+- `description`: Shown in search results and page meta — one sentence, no period
+
+### 4. Opening Paragraph
+
+Start with a plain prose paragraph (no heading) that explains what the feature is and why it matters. Keep it to 2–4 sentences. Do not repeat the `description` verbatim.
+
+### 5. Benefits List (Optional)
+
+For feature docs, a bold-bullet benefits list after the opening paragraph is conventional:
+
+```mdx
+**Benefits:**
+
+- **Proactive management** — Description of why this matters
+- **Granular control** — Description
+- **Flexible conditions** — Description
+```
+
+### 6. Section Structure
+
+Use `##` for top-level sections and `###` for subsections. Never use `#` (reserved for the page title) or go deeper than `###` in most docs.
+
+---
+
+## Mintlify MDX Components
+
+### Callouts
+
+```mdx
+<Note>
+  Informational note — use for helpful context or clarifications.
+</Note>
+
+<Info>
+  Similar to Note but for more prominent informational content.
+</Info>
+
+<Warning>
+  Use for gotchas, required conditions, or things that will break if ignored.
+</Warning>
+
+<Check>
+  Use for best practices, recommendations, or "do this" guidance.
+</Check>
+```
+
+### Steps (for configuration workflows)
+
+```mdx
+<Steps>
+  <Step title="Navigate to the feature">
+    Instructions here.
+  </Step>
+
+  <Step title="Configure settings">
+    More instructions.
+  </Step>
+</Steps>
+```
+
+### Code Blocks
+
+Single language:
+```mdx
+```json
+{ "key": "value" }
+```
+```
+
+Multiple languages side by side:
+```mdx
+<CodeGroup>
+```bash cURL
+curl ...
+```
+
+```javascript JavaScript
+fetch(...)
+```
+
+```python Python
+import requests
+```
+</CodeGroup>
+```
+
+### Tables
+
+```mdx
+| Column | Column |
+|--------|--------|
+| Value  | Value  |
+```
+
+Pipe-align all columns. Use bold (`**text**`) in first column when listing settings or fields.
+
+### Cards and Links
+
+```mdx
+<Card icon="book-open" horizontal={true} href="/docs/..." title="Related Doc Title" />
+```
+
+Use `horizontal={true}` for inline card links at the bottom of a page.
+
+### Frames (screenshots)
+
+```mdx
+<Frame>
+  ![Alt text](/public/images/docs/Section/Page/image.png)
+</Frame>
+```
+
+Only include `<Frame>` blocks when actual screenshots exist in the repo at the referenced path. **Do not include placeholder image references** — broken image links will fail the `mint broken-links` check.
+
+---
+
+## Webhook Payload Sections
+
+When documenting a feature that emits webhooks, follow this structure:
+
+```mdx
+### Webhook Payload
+
+**Event type:** `event.name.here`
+
+```json
+{
+  "event_type": "event.name.here",
+  "alert_type": "descriptor",
+  "alert_status": "warning",
+  ...
+}
+```
+
+### Webhook Fields
+
+| Field | Description |
+|-------|-------------|
+| `field_name` | What it contains |
+| `nested.field` | Description |
+```
+
+Model new webhook events on existing ones — see `docs/wallet/low-balance-alert.mdx` (event: `wallet.alert`) and `docs/product-catalogue/features/wallet-balance-alert.mdx` (event: `feature.wallet_balance.alert`). For usage-based alerts, follow the `customer.usage.alert` / `feature.usage.alert` pattern established in `docs/customers/threshold-notifications.mdx`.
+
+---
+
+## Navigation: docs.json
+
+After writing a new file, **always add it to `docs.json`**.
+
+The navigation lives in `navigation.tabs[0].groups` (the Documentation tab). Structure:
+
+```json
+{
+  "group": "Group Name",
+  "icon": "icon-name",
+  "pages": [
+    "docs/path/to/page",
+    {
+      "group": "Sub-group Name",
+      "pages": [
+        "docs/path/to/nested-page"
+      ]
+    }
+  ]
+}
+```
+
+**Rules:**
+- Flat page paths are relative to repo root, no `.mdx` extension
+- Sub-groups use the same `{ "group": "...", "pages": [...] }` shape — no `icon` on sub-groups
+- Always add new pages immediately after the most relevant existing page in the same section
+- Never create a new top-level group without checking if an existing group is the right home
+
+**Common icon names:** `users`, `wallet`, `webhook`, `layer-group`, `refresh`, `file-text`, `gear`, `bell`, `shield`, `code`, `book-open`, `plug`
+
+---
+
+## Validation Commands
+
+Run these **before opening a PR**. Both use Node 22 (mintlify does not support Node 25+).
+
+### Check for broken links
+
+```bash
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" \
+  /opt/homebrew/opt/node@22/bin/node \
+  /opt/homebrew/lib/node_modules/mintlify/node_modules/@mintlify/cli/bin/index.js \
+  broken-links
+```
+
+- **Pass**: no broken links in your new file — proceed to PR
+- **Fail**: fix every broken link reported in your file; pre-existing broken links in other files are not your responsibility
+- The most common cause: referencing a screenshot path in `<Frame>` that doesn't exist in `public/images/`
+
+### Validate build structure
+
+```bash
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" \
+  /opt/homebrew/opt/node@22/bin/node \
+  /opt/homebrew/lib/node_modules/mintlify/node_modules/@mintlify/cli/bin/index.js \
+  validate
+```
+
+- Confirms `docs.json` is valid, all referenced pages exist, and no structural errors
+- Pre-existing warning: `Invalid import path react in /components/Callout.tsx` — this is a known upstream issue, ignore it
+
+### Dev server (visual check)
+
+```bash
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" \
+  /opt/homebrew/opt/node@22/bin/node \
+  /opt/homebrew/lib/node_modules/mintlify/node_modules/@mintlify/cli/bin/index.js \
+  dev --port 3333
+```
+
+The `.claude/launch.json` in this repo is configured to use this exact path. Use `preview_start` with the `"docs"` configuration.
+
+**Node version note:** The system has Node 25 as default (`/opt/homebrew/bin/node`), which is unsupported by mintlify. Always prefix with `PATH="/opt/homebrew/opt/node@22/bin:$PATH"` or use the absolute node@22 binary path.
+
+---
+
+## Editorial Voice
+
+| Do | Don't |
+|----|-------|
+| "Wallet balance alerts fire when…" | "We've added exciting new alerts that…" |
+| "Configure thresholds per wallet" | "Powerful per-wallet configuration" |
+| "Set `alert_enabled: true` to activate" | "Simply toggle the switch to enable" |
+| Present tense: "Alerts trigger on…" | Future: "Alerts will trigger on…" |
+| Second-person: "You can configure…" | First-person: "We allow you to…" |
+
+- **No marketing adjectives**: skip "powerful", "flexible", "seamless", "robust", "easy"
+- **Name the mechanism**: say what the API field or UI element is called
+- **One idea per sentence**: split compound sentences
+- **No trailing summaries**: don't end with "In summary, …" or "By using X, you can…"
+
+---
+
+## Checklist Before Opening a PR
+
+- [ ] File is in the right directory (`docs/<section>/`)
+- [ ] Frontmatter has `title` and `description`
+- [ ] Page is added to `docs.json` in the correct group
+- [ ] No `<Frame>` blocks reference images that don't exist in the repo
+- [ ] `mint broken-links` passes with no new errors
+- [ ] `mint validate` passes (the pre-existing `Callout.tsx` warning is acceptable)
+- [ ] Dev server renders the page correctly (check heading hierarchy, code block syntax, table alignment)
+- [ ] Internal links use `/docs/...` paths (not relative `../` paths)
+
+---
+
+## Known Pre-Existing Issues (Do Not Fix Unless Asked)
+
+- **81 broken image links** across 29 files — all missing `/public/images/` screenshot assets. These exist in `main` and are not blocking.
+- **`components/Callout.tsx` react import warning** — flagged by `mint validate`, pre-existing, not fixable from docs content.

--- a/docs.json
+++ b/docs.json
@@ -150,12 +150,7 @@
               "docs/customers/create",
               "docs/customers/customer-portal",
               "docs/customers/archive",
-              {
-                "group": "Alerts and Notifications",
-                "pages": [
-                  "docs/customers/threshold-notifications"
-                ]
-              }
+              "docs/customers/threshold-notifications"
             ]
           },
           {

--- a/docs/getting-started/architecture.mdx
+++ b/docs/getting-started/architecture.mdx
@@ -1,261 +1,206 @@
 ---
-title: "Architecture"
-description: "This document outlines the core architecture components of the Flexprice platform, how they interact, and their respective responsibilities."
+title: "Architecture & Trust"
+description: "How Flexprice Cloud is engineered to be secure, reliable, scalable, and easy to operate — a transparent look at the platform that runs your billing."
 ---
 
-## Building Blocks
+Flexprice sits in the critical path of your revenue. Every usage event you send, every invoice we generate, and every entitlement check your product makes depends on this platform being correct and available. This page is a transparent, engineering-level overview of how **Flexprice Cloud** is built and operated, written for the technical leaders evaluating whether to trust us with their monetization stack.
 
-### Core Services
+We've deliberately kept this honest and concrete rather than aspirational. If you need deeper detail for a security review or vendor assessment, reach out to [support@flexprice.io](mailto:support@flexprice.io) and we'll walk your team through it.
 
-#### API Service
+## Design Principles
 
-The API service is the primary entry point for client applications interacting with Flexprice. It handles all HTTP requests, processes them through appropriate business logic, and returns responses. The API service:
+Every architectural decision in Flexprice Cloud is measured against four goals.
 
-- Exposes RESTful endpoints for various Flexprice functionalities
-- Handles authentication and authorization
-- Writes data to PostgreSQL for persistent storage
-- Publishes events to Kafka for asynchronous processing
-- Initiates Temporal workflows for complex or scheduled processes
+<CardGroup cols={2}>
+  <Card title="Safe" icon="shield-check">
+    Strict tenant isolation, encryption in transit and at rest, private-by-default networking, least-privilege access, and automated backups. Your data is never exposed to the public internet at the database layer.
+  </Card>
+  <Card title="Robust" icon="heart-pulse">
+    Durable workflow orchestration, automatic retries, multi-AZ redundancy, and zero-downtime deployments with automatic rollback. The system is designed to keep running through node failures and traffic spikes.
+  </Card>
+  <Card title="Scalable" icon="arrows-up-down-left-right">
+    A decoupled, event-driven design where each service scales independently and horizontally. Usage ingestion, billing, and analytics grow without re-architecting.
+  </Card>
+  <Card title="Maintainable" icon="wrench">
+    Everything is defined as code and deployed through GitOps. Infrastructure is reproducible, auditable, and recoverable — no snowflake servers, no manual configuration drift.
+  </Card>
+</CardGroup>
+
+## Platform at a Glance
+
+Flexprice Cloud runs entirely on **Amazon Web Services**, using managed and battle-tested building blocks rather than bespoke infrastructure. The platform is containerized, runs across multiple Availability Zones, and is provisioned end-to-end through infrastructure-as-code.
+
+| Concern | What we use | Why it matters to you |
+|---|---|---|
+| **Cloud provider** | AWS (multiple regions) | Mature security, compliance, and durability guarantees from the underlying platform |
+| **Compute** | Containerized services on AWS ECS, ARM/Graviton instances across multiple AZs | Resilient to single-node and single-AZ failures; cost-efficient and energy-efficient |
+| **Transactional data** | PostgreSQL | ACID-compliant store for customers, plans, subscriptions, and invoices |
+| **Usage analytics** | ClickHouse | Column-store built for billions of usage events and real-time aggregation |
+| **Event streaming** | Kafka | Decouples ingestion from processing and absorbs traffic spikes |
+| **Workflow orchestration** | Temporal | Durable, retryable execution for billing cycles and long-running jobs |
+| **Delivery** | GitOps (Argo CD) + Terraform/Terragrunt | Every change is version-controlled, reviewed, and reproducible |
+| **Backups** | Automated AWS Backup snapshots, hourly | Point-in-time recovery of analytical data |
+
+## Request Lifecycle
+
+The platform is split into independently deployable services, each with a single responsibility. A request never blocks on slow downstream work — anything that can be asynchronous is handed off to Kafka or Temporal.
 
 ```mermaid
 graph LR
+    classDef client fill:#f5f5f5,stroke:#888888
     classDef services fill:#e6e6fa,stroke:#9370db
     classDef infrastructure fill:#fffacd,stroke:#daa520
-    classDef client fill:#f5f5f5,stroke:#888888
 
-    client["Client"]:::client
-    api["API Service"]:::services
-    postgres[(PostgreSQL)]:::infrastructure
+    client["Your Application"]:::client
+    api["API Service<br/>(multi-AZ, auto-scaled)"]:::services
     kafka[Kafka]:::infrastructure
+    consumer["Consumer Service"]:::services
+    worker["Temporal Worker"]:::services
+    postgres[(PostgreSQL)]:::infrastructure
+    clickhouse[(ClickHouse)]:::infrastructure
     temporal[Temporal]:::infrastructure
 
-    client -- "HTTP Request" --> api
+    client -- "HTTPS (API key auth)" --> api
     api -- "Read/Write" --> postgres
-    api -- "Publish Events" --> kafka
-    api -- "Start Workflow" --> temporal
+    api -- "Publish usage events" --> kafka
+    api -- "Start workflow" --> temporal
+    kafka -- "Consume" --> consumer
+    consumer -- "Store events" --> clickhouse
+    consumer -- "Update state" --> postgres
+    temporal -- "Execute" --> worker
+    worker -- "Read/Write" --> postgres
+    worker -- "Publish events" --> kafka
     api -- "Response" --> client
 ```
 
-#### Worker Service
+- **API Service** — the only internet-facing tier. It authenticates requests, validates input, persists transactional state to PostgreSQL, and hands heavy or asynchronous work to Kafka and Temporal so client latency stays low.
+- **Consumer Service** — drains usage events from Kafka, writes them to ClickHouse for analytics, and updates derived state. Because it is decoupled, a burst of usage traffic queues safely instead of overwhelming the system.
+- **Temporal Worker** — executes durable workflows such as billing cycles, invoice generation, and scheduled jobs. Temporal guarantees these run to completion with automatic retries, even across deploys or node restarts.
 
-The Worker service consumes messages from Kafka and processes them asynchronously:
+This separation means each tier scales on its own signal: the API tier on request rate, the consumer on event backlog, and the worker on workflow load.
 
-- Subscribes to configured Kafka topics
-- Processes incoming events (usage data, system events, etc.)
-- Writes aggregated data to ClickHouse for analytics
-- Updates PostgreSQL when necessary based on event processing
-- Handles event-driven business logic that doesn't need immediate response
+## Where Your Data Lives
+
+Flexprice Cloud is deployed as **fully isolated stacks in multiple AWS regions**, today including the **United States (Oregon)** and **India (Mumbai)**, with additional regions provisioned on request. Each region is a self-contained deployment with its own compute, databases, and networking — data does not cross regional boundaries, which helps you meet data-residency requirements.
+
+<Card title="Data residency" icon="earth-americas">
+  Choose the region your customer and usage data is stored and processed in. Each region runs an independent copy of the full Flexprice stack inside its own isolated network (VPC).
+</Card>
+
+Within a region, every Flexprice entity is scoped to a **tenant** and an **environment** (for example, production vs. sandbox). This tenancy boundary is enforced at the application layer on every query, so one customer can never read or write another customer's data.
+
+## Compute & Deployments
+
+Flexprice services run as containers on AWS ECS, spread across multiple Availability Zones using a mix of on-demand and spot capacity for resilience and cost efficiency.
+
+- **Multi-AZ by design** — services are distributed across Availability Zones, so the loss of any single zone does not take the platform down.
+- **Horizontal auto-scaling** — each service runs multiple replicas and scales out under load. Stateless services can be added or removed without disruption.
+- **Zero-downtime deployments** — releases roll out gradually with health checks. A built-in **deployment circuit breaker automatically rolls back** any release that fails to come up healthy, so a bad deploy never reaches your customers.
+- **Self-healing** — unhealthy or terminated tasks are automatically rescheduled onto healthy capacity.
 
 ```mermaid
-graph LR
+graph TB
     classDef services fill:#e6e6fa,stroke:#9370db
     classDef infrastructure fill:#fffacd,stroke:#daa520
 
-    kafka[Kafka]:::infrastructure
-    worker["Worker Service"]:::services
-    clickhouse[(ClickHouse)]:::infrastructure
-    postgres[(PostgreSQL)]:::infrastructure
+    lb["Load Balancer"]:::infrastructure
+    az1["AZ-a<br/>API replicas"]:::services
+    az2["AZ-b<br/>API replicas"]:::services
+    az3["AZ-c<br/>Worker / Consumer replicas"]:::services
 
-    kafka -- "Message Consumption" --> worker
-    worker -- "Store Events" --> clickhouse
-    worker -- "Update State" --> postgres
+    lb --> az1
+    lb --> az2
+    lb --> az3
 ```
 
-#### Temporal Worker
+## Data Layer
 
-The Temporal Worker executes scheduled and long-running workflows:
+Flexprice uses the right datastore for each job and protects both.
 
-- Runs background job workflows such as billing cycles
-- Processes multi-step operations that require state management
-- Handles cron jobs for scheduled tasks
-- Will eventually manage webhook delivery and related workflows
-- Interacts with PostgreSQL and can trigger Kafka events
+#### PostgreSQL — system of record
 
-```mermaid
-graph LR
-    classDef services fill:#e6e6fa,stroke:#9370db
-    classDef infrastructure fill:#fffacd,stroke:#daa520
+The transactional store for customers, plans, subscriptions, entitlements, invoices, and payments. PostgreSQL gives us ACID guarantees, so financial state transitions are consistent and correct. It is reached only from inside the private network.
 
-    temporal[Temporal]:::infrastructure
-    temporal_worker["Temporal Worker"]:::services
-    postgres[(PostgreSQL)]:::infrastructure
-    kafka[Kafka]:::infrastructure
+#### ClickHouse — usage at scale
 
-    temporal -- "Execute Workflow" --> temporal_worker
-    temporal_worker -- "Read/Write Data" --> postgres
-    temporal_worker -- "Publish Events" --> kafka
-```
+A purpose-built column store for high-volume usage events. ClickHouse lets Flexprice ingest and aggregate billions of events and answer real-time usage and billing queries that a traditional database could not.
 
-### Infrastructure Components
+Both databases are:
 
-#### PostgreSQL
+- **Private by default** — reachable only through internal load balancers inside the VPC, in private subnets. There is **no public internet path to your data at the database layer**.
+- **Encrypted at rest** — backed by encrypted storage volumes.
+- **Backed up automatically** — analytical storage is snapshotted hourly via AWS Backup with retained recovery points, and storage volumes use a *retain* policy so data survives infrastructure changes.
 
-PostgreSQL serves as the primary transactional database storing all core business data:
+## Reliability & Resilience
 
-- Customer data
-- Subscription information
-- Plan configurations
-- Feature entitlements
-- User accounts and authorization data
+We assume failure will happen and design so that it is survivable and recoverable.
 
-#### ClickHouse
+<CardGroup cols={2}>
+  <Card title="Durable workflows" icon="rotate">
+    Billing runs and invoice generation execute on Temporal, which persists every step. Interruptions resume exactly where they left off — no lost or double-billed cycles.
+  </Card>
+  <Card title="Buffered ingestion" icon="layer-group">
+    Usage events flow through Kafka, so a downstream slowdown or spike is absorbed by the queue instead of dropping data or rejecting requests.
+  </Card>
+  <Card title="Automated backups" icon="floppy-disk">
+    Hourly snapshots of analytical data with documented restore runbooks. Storage volumes retain data through node replacement and upgrades.
+  </Card>
+  <Card title="Redundant compute" icon="server">
+    Multiple replicas of every service across Availability Zones, with automatic rescheduling and rollback on failure.
+  </Card>
+</CardGroup>
 
-ClickHouse is an OLAP database optimized for high-performance analytics:
+We are actively rolling out **real-time database replication** for the analytics tier to add automatic failover on top of today's snapshot-based recovery — part of a continuously hardening reliability roadmap.
 
-- Stores usage metrics and events
-- Supports real-time analytics queries
-- Enables fast aggregation for billing calculations
-- Provides data for usage dashboards and reporting
+## Scalability
 
-#### Kafka
+The architecture scales by adding capacity, not by rewriting code.
 
-Kafka serves as the message broker and event streaming platform:
+- **Decoupled services** — ingestion, processing, billing, and analytics are separate tiers connected by Kafka and Temporal. Each scales independently against its own workload.
+- **Stateless application tier** — API and worker services hold no local state, so scaling out is as simple as adding replicas.
+- **Stream-based ingestion** — Kafka smooths spikes and lets the consumer tier process at a sustainable rate without backpressure on your application.
+- **Analytics built for volume** — ClickHouse is engineered for high-cardinality, high-throughput usage data, so metering performance holds as your event volume grows.
 
-- Decouples services for async processing
-- Enables event-driven architecture
-- Ensures reliable delivery of events between services
-- Provides buffering during traffic spikes
+## Security
 
-#### Temporal
+Security is layered from the network edge down to individual queries.
 
-Temporal is a workflow orchestration platform that manages complex, stateful processes:
+| Layer | Control |
+|---|---|
+| **Network** | Isolated VPC per region; databases in private subnets with no public route; internal-only load balancers for data services |
+| **Transport** | TLS/HTTPS for all client traffic |
+| **Storage** | Encryption at rest for databases and backups |
+| **Authentication** | API-key authentication on every request; keys are scoped and revocable |
+| **Tenant isolation** | Every entity is scoped to tenant + environment, enforced on every read and write |
+| **Access control** | Least-privilege IAM roles; protected/guarded critical infrastructure resources |
+| **Auditability** | Infrastructure and application changes are version-controlled and reviewed before they ship |
 
-- Coordinates long-running business processes
-- Provides durability and reliability for mission-critical workflows
-- Manages scheduled jobs via cron-like functionality
-- Handles retries and error recovery automatically
+<Warning>
+  Treat your Flexprice API keys like passwords. Use server-side keys, never expose them in client-side code or public repositories, and rotate them if you suspect exposure.
+</Warning>
 
-## Functional Building Blocks
+## Operations & Observability
 
-Flexprice is architected as a set of composable building blocks, each handling specific aspects of usage-based billing and subscription management. These blocks can be used independently or together, providing flexibility in how the platform is deployed and utilized.
+A mature platform is one you can reason about and recover.
 
-#### Usage Metering Layer
+- **Infrastructure as code** — the entire platform is defined in Terraform/Terragrunt and Kubernetes manifests. Environments are reproducible and there are no undocumented, hand-built servers.
+- **GitOps delivery** — changes are applied through Argo CD from version control, giving a complete, auditable history of what is running and why.
+- **Monitoring** — services are instrumented and observed through Grafana and error-tracking tooling, so we detect and respond to issues quickly.
+- **Documented runbooks** — recovery procedures (restore from snapshot, scaling, upgrades) are written down and rehearsed, not improvised during an incident.
 
-**Core Functionality:**
+## Want Full Control? Self-Host.
 
-- Collection and processing of usage events
-- Real-time event ingestion
-- Usage analytics and reporting
+Flexprice is open source. If your requirements call for running the platform inside your own cloud account or on-premises, you can deploy the exact same architecture yourself.
 
-**Interactions:**
+<CardGroup cols={2}>
+  <Card title="Self-Hosting Guide" icon="book" href="/docs/getting-started/self-hosting-guide">
+    Run the full Flexprice stack with Docker Compose.
+  </Card>
+  <Card title="Self-Hosting on AWS" icon="aws" href="/docs/getting-started/self-hosting-aws">
+    A production reference deployment on AWS.
+  </Card>
+</CardGroup>
 
-- Provides usage data to the Pricing Layer for cost calculations
-- Feeds data to the Subscription Layer for usage-based billing
-- Supports the Entitlement Layer with metering for feature limits
+## Talk to Us
 
-```mermaid
-graph TB
-    classDef functional fill:#f0e68c,stroke:#8b8b00
-    classDef infrastructure fill:#fffacd,stroke:#daa520
-    classDef external fill:#f5f5f5,stroke:#888888
-
-    client["Client App"]:::external
-    metrics["Usage Metering Layer"]:::functional
-    clickhouse[(ClickHouse)]:::infrastructure
-    pricing["Pricing Layer"]:::functional
-    subscription["Subscription Layer"]:::functional
-
-    client -- "Send Events" --> metrics
-    metrics -- "Store Data" --> clickhouse
-    metrics -- "Usage Data" --> pricing
-    metrics -- "Usage Data" --> subscription
-```
-
-#### Pricing Layer
-
-**Core Functionality:**
-
-- Defines flexible pricing models
-- Supports various pricing strategies (tiered, volume, graduated, etc.)
-- Handles price calculations based on usage
-
-**Interactions:**
-
-- Works with Usage Metrics to calculate costs
-- Feeds into Subscription & Billing for invoice generation
-- Can be configured differently per subscription
-
-```mermaid
-graph TB
-    classDef functional fill:#f0e68c,stroke:#8b8b00
-    classDef infrastructure fill:#fffacd,stroke:#daa520
-
-    metrics["Usage Metering Layer"]:::functional
-    pricing["Pricing Layer"]:::functional
-    subscription["Subscription & Billing"]:::functional
-    postgres[(PostgreSQL)]:::infrastructure
-
-    metrics -- "Usage Data" --> pricing
-    pricing -- "Store Models" --> postgres
-    pricing -- "Cost Calculation" --> subscription
-```
-
-#### Subscription & Billing Layer
-
-**Core Functionality:**
-
-- Manages subscription lifecycle
-- Handles recurring and usage-based billing
-- Processes invoices and payments
-- Manages customer accounts and balances
-
-**Interactions:**
-
-- Uses Pricing Layer to determine charges
-- Leverages Entitlement Layer to provision appropriate access
-- Coordinates with Usage Metrics for consumption-based billing
-- Utilizes Temporal for scheduled operations like billing cycles
-
-```mermaid
-graph TB
-    classDef functional fill:#f0e68c,stroke:#8b8b00
-    classDef services fill:#e6e6fa,stroke:#9370db
-    classDef infrastructure fill:#fffacd,stroke:#daa520
-
-    subscription["Subscription & Billing"]:::functional
-    pricing["Pricing Layer"]:::functional
-    entitlement["Entitlement Layer"]:::functional
-    metrics["Usage Metrics"]:::functional
-    temporal[Temporal]:::infrastructure
-    postgres[(PostgreSQL)]:::infrastructure
-
-    pricing -- "Pricing Data" --> subscription
-    metrics -- "Usage Data" --> subscription
-    subscription -- "Store Data" --> postgres
-    subscription -- "Provision Access" --> entitlement
-    temporal -- "Scheduled Billing" --> subscription
-```
-
-#### Feature & Entitlement Layer
-
-**Core Functionality:**
-
-- Controls access to features
-- Enforces usage limits and quotas
-- Provides feature flagging capabilities
-- Manages customer entitlements
-
-**Interactions:**
-
-- References Subscription data to determine entitlements
-- Uses Usage Metrics to enforce limits
-- Can be queried by client applications for access control
-
-```mermaid
-graph TB
-    classDef functional fill:#f0e68c,stroke:#8b8b00
-    classDef infrastructure fill:#fffacd,stroke:#daa520
-    classDef external fill:#f5f5f5,stroke:#888888
-
-    client["Client App"]:::external
-    entitlement["Feature & Entitlement Layer"]:::functional
-    subscription["Subscription Layer"]:::functional
-    metrics["Usage Metrics"]:::functional
-    postgres[(PostgreSQL)]:::infrastructure
-
-    client -- "Access Check" --> entitlement
-    subscription -- "Entitlement Data" --> entitlement
-    metrics -- "Usage Limits" --> entitlement
-    entitlement -- "Store Configuration" --> postgres
-    entitlement -- "Access Control" --> client
-```
+We're happy to go deeper — network diagrams, data handling, incident process, or a vendor security questionnaire. Reach the team at [support@flexprice.io](mailto:support@flexprice.io).

--- a/docs/getting-started/architecture.mdx
+++ b/docs/getting-started/architecture.mdx
@@ -1,206 +1,261 @@
 ---
-title: "Architecture & Trust"
-description: "How Flexprice Cloud is engineered to be secure, reliable, scalable, and easy to operate — a transparent look at the platform that runs your billing."
+title: "Architecture"
+description: "This document outlines the core architecture components of the Flexprice platform, how they interact, and their respective responsibilities."
 ---
 
-Flexprice sits in the critical path of your revenue. Every usage event you send, every invoice we generate, and every entitlement check your product makes depends on this platform being correct and available. This page is a transparent, engineering-level overview of how **Flexprice Cloud** is built and operated, written for the technical leaders evaluating whether to trust us with their monetization stack.
+## Building Blocks
 
-We've deliberately kept this honest and concrete rather than aspirational. If you need deeper detail for a security review or vendor assessment, reach out to [support@flexprice.io](mailto:support@flexprice.io) and we'll walk your team through it.
+### Core Services
 
-## Design Principles
+#### API Service
 
-Every architectural decision in Flexprice Cloud is measured against four goals.
+The API service is the primary entry point for client applications interacting with Flexprice. It handles all HTTP requests, processes them through appropriate business logic, and returns responses. The API service:
 
-<CardGroup cols={2}>
-  <Card title="Safe" icon="shield-check">
-    Strict tenant isolation, encryption in transit and at rest, private-by-default networking, least-privilege access, and automated backups. Your data is never exposed to the public internet at the database layer.
-  </Card>
-  <Card title="Robust" icon="heart-pulse">
-    Durable workflow orchestration, automatic retries, multi-AZ redundancy, and zero-downtime deployments with automatic rollback. The system is designed to keep running through node failures and traffic spikes.
-  </Card>
-  <Card title="Scalable" icon="arrows-up-down-left-right">
-    A decoupled, event-driven design where each service scales independently and horizontally. Usage ingestion, billing, and analytics grow without re-architecting.
-  </Card>
-  <Card title="Maintainable" icon="wrench">
-    Everything is defined as code and deployed through GitOps. Infrastructure is reproducible, auditable, and recoverable — no snowflake servers, no manual configuration drift.
-  </Card>
-</CardGroup>
-
-## Platform at a Glance
-
-Flexprice Cloud runs entirely on **Amazon Web Services**, using managed and battle-tested building blocks rather than bespoke infrastructure. The platform is containerized, runs across multiple Availability Zones, and is provisioned end-to-end through infrastructure-as-code.
-
-| Concern | What we use | Why it matters to you |
-|---|---|---|
-| **Cloud provider** | AWS (multiple regions) | Mature security, compliance, and durability guarantees from the underlying platform |
-| **Compute** | Containerized services on AWS ECS, ARM/Graviton instances across multiple AZs | Resilient to single-node and single-AZ failures; cost-efficient and energy-efficient |
-| **Transactional data** | PostgreSQL | ACID-compliant store for customers, plans, subscriptions, and invoices |
-| **Usage analytics** | ClickHouse | Column-store built for billions of usage events and real-time aggregation |
-| **Event streaming** | Kafka | Decouples ingestion from processing and absorbs traffic spikes |
-| **Workflow orchestration** | Temporal | Durable, retryable execution for billing cycles and long-running jobs |
-| **Delivery** | GitOps (Argo CD) + Terraform/Terragrunt | Every change is version-controlled, reviewed, and reproducible |
-| **Backups** | Automated AWS Backup snapshots, hourly | Point-in-time recovery of analytical data |
-
-## Request Lifecycle
-
-The platform is split into independently deployable services, each with a single responsibility. A request never blocks on slow downstream work — anything that can be asynchronous is handed off to Kafka or Temporal.
+- Exposes RESTful endpoints for various Flexprice functionalities
+- Handles authentication and authorization
+- Writes data to PostgreSQL for persistent storage
+- Publishes events to Kafka for asynchronous processing
+- Initiates Temporal workflows for complex or scheduled processes
 
 ```mermaid
 graph LR
-    classDef client fill:#f5f5f5,stroke:#888888
     classDef services fill:#e6e6fa,stroke:#9370db
     classDef infrastructure fill:#fffacd,stroke:#daa520
+    classDef client fill:#f5f5f5,stroke:#888888
 
-    client["Your Application"]:::client
-    api["API Service<br/>(multi-AZ, auto-scaled)"]:::services
-    kafka[Kafka]:::infrastructure
-    consumer["Consumer Service"]:::services
-    worker["Temporal Worker"]:::services
+    client["Client"]:::client
+    api["API Service"]:::services
     postgres[(PostgreSQL)]:::infrastructure
-    clickhouse[(ClickHouse)]:::infrastructure
+    kafka[Kafka]:::infrastructure
     temporal[Temporal]:::infrastructure
 
-    client -- "HTTPS (API key auth)" --> api
+    client -- "HTTP Request" --> api
     api -- "Read/Write" --> postgres
-    api -- "Publish usage events" --> kafka
-    api -- "Start workflow" --> temporal
-    kafka -- "Consume" --> consumer
-    consumer -- "Store events" --> clickhouse
-    consumer -- "Update state" --> postgres
-    temporal -- "Execute" --> worker
-    worker -- "Read/Write" --> postgres
-    worker -- "Publish events" --> kafka
+    api -- "Publish Events" --> kafka
+    api -- "Start Workflow" --> temporal
     api -- "Response" --> client
 ```
 
-- **API Service** — the only internet-facing tier. It authenticates requests, validates input, persists transactional state to PostgreSQL, and hands heavy or asynchronous work to Kafka and Temporal so client latency stays low.
-- **Consumer Service** — drains usage events from Kafka, writes them to ClickHouse for analytics, and updates derived state. Because it is decoupled, a burst of usage traffic queues safely instead of overwhelming the system.
-- **Temporal Worker** — executes durable workflows such as billing cycles, invoice generation, and scheduled jobs. Temporal guarantees these run to completion with automatic retries, even across deploys or node restarts.
+#### Worker Service
 
-This separation means each tier scales on its own signal: the API tier on request rate, the consumer on event backlog, and the worker on workflow load.
+The Worker service consumes messages from Kafka and processes them asynchronously:
 
-## Where Your Data Lives
-
-Flexprice Cloud is deployed as **fully isolated stacks in multiple AWS regions**, today including the **United States (Oregon)** and **India (Mumbai)**, with additional regions provisioned on request. Each region is a self-contained deployment with its own compute, databases, and networking — data does not cross regional boundaries, which helps you meet data-residency requirements.
-
-<Card title="Data residency" icon="earth-americas">
-  Choose the region your customer and usage data is stored and processed in. Each region runs an independent copy of the full Flexprice stack inside its own isolated network (VPC).
-</Card>
-
-Within a region, every Flexprice entity is scoped to a **tenant** and an **environment** (for example, production vs. sandbox). This tenancy boundary is enforced at the application layer on every query, so one customer can never read or write another customer's data.
-
-## Compute & Deployments
-
-Flexprice services run as containers on AWS ECS, spread across multiple Availability Zones using a mix of on-demand and spot capacity for resilience and cost efficiency.
-
-- **Multi-AZ by design** — services are distributed across Availability Zones, so the loss of any single zone does not take the platform down.
-- **Horizontal auto-scaling** — each service runs multiple replicas and scales out under load. Stateless services can be added or removed without disruption.
-- **Zero-downtime deployments** — releases roll out gradually with health checks. A built-in **deployment circuit breaker automatically rolls back** any release that fails to come up healthy, so a bad deploy never reaches your customers.
-- **Self-healing** — unhealthy or terminated tasks are automatically rescheduled onto healthy capacity.
+- Subscribes to configured Kafka topics
+- Processes incoming events (usage data, system events, etc.)
+- Writes aggregated data to ClickHouse for analytics
+- Updates PostgreSQL when necessary based on event processing
+- Handles event-driven business logic that doesn't need immediate response
 
 ```mermaid
-graph TB
+graph LR
     classDef services fill:#e6e6fa,stroke:#9370db
     classDef infrastructure fill:#fffacd,stroke:#daa520
 
-    lb["Load Balancer"]:::infrastructure
-    az1["AZ-a<br/>API replicas"]:::services
-    az2["AZ-b<br/>API replicas"]:::services
-    az3["AZ-c<br/>Worker / Consumer replicas"]:::services
+    kafka[Kafka]:::infrastructure
+    worker["Worker Service"]:::services
+    clickhouse[(ClickHouse)]:::infrastructure
+    postgres[(PostgreSQL)]:::infrastructure
 
-    lb --> az1
-    lb --> az2
-    lb --> az3
+    kafka -- "Message Consumption" --> worker
+    worker -- "Store Events" --> clickhouse
+    worker -- "Update State" --> postgres
 ```
 
-## Data Layer
+#### Temporal Worker
 
-Flexprice uses the right datastore for each job and protects both.
+The Temporal Worker executes scheduled and long-running workflows:
 
-#### PostgreSQL — system of record
+- Runs background job workflows such as billing cycles
+- Processes multi-step operations that require state management
+- Handles cron jobs for scheduled tasks
+- Will eventually manage webhook delivery and related workflows
+- Interacts with PostgreSQL and can trigger Kafka events
 
-The transactional store for customers, plans, subscriptions, entitlements, invoices, and payments. PostgreSQL gives us ACID guarantees, so financial state transitions are consistent and correct. It is reached only from inside the private network.
+```mermaid
+graph LR
+    classDef services fill:#e6e6fa,stroke:#9370db
+    classDef infrastructure fill:#fffacd,stroke:#daa520
 
-#### ClickHouse — usage at scale
+    temporal[Temporal]:::infrastructure
+    temporal_worker["Temporal Worker"]:::services
+    postgres[(PostgreSQL)]:::infrastructure
+    kafka[Kafka]:::infrastructure
 
-A purpose-built column store for high-volume usage events. ClickHouse lets Flexprice ingest and aggregate billions of events and answer real-time usage and billing queries that a traditional database could not.
+    temporal -- "Execute Workflow" --> temporal_worker
+    temporal_worker -- "Read/Write Data" --> postgres
+    temporal_worker -- "Publish Events" --> kafka
+```
 
-Both databases are:
+### Infrastructure Components
 
-- **Private by default** — reachable only through internal load balancers inside the VPC, in private subnets. There is **no public internet path to your data at the database layer**.
-- **Encrypted at rest** — backed by encrypted storage volumes.
-- **Backed up automatically** — analytical storage is snapshotted hourly via AWS Backup with retained recovery points, and storage volumes use a *retain* policy so data survives infrastructure changes.
+#### PostgreSQL
 
-## Reliability & Resilience
+PostgreSQL serves as the primary transactional database storing all core business data:
 
-We assume failure will happen and design so that it is survivable and recoverable.
+- Customer data
+- Subscription information
+- Plan configurations
+- Feature entitlements
+- User accounts and authorization data
 
-<CardGroup cols={2}>
-  <Card title="Durable workflows" icon="rotate">
-    Billing runs and invoice generation execute on Temporal, which persists every step. Interruptions resume exactly where they left off — no lost or double-billed cycles.
-  </Card>
-  <Card title="Buffered ingestion" icon="layer-group">
-    Usage events flow through Kafka, so a downstream slowdown or spike is absorbed by the queue instead of dropping data or rejecting requests.
-  </Card>
-  <Card title="Automated backups" icon="floppy-disk">
-    Hourly snapshots of analytical data with documented restore runbooks. Storage volumes retain data through node replacement and upgrades.
-  </Card>
-  <Card title="Redundant compute" icon="server">
-    Multiple replicas of every service across Availability Zones, with automatic rescheduling and rollback on failure.
-  </Card>
-</CardGroup>
+#### ClickHouse
 
-We are actively rolling out **real-time database replication** for the analytics tier to add automatic failover on top of today's snapshot-based recovery — part of a continuously hardening reliability roadmap.
+ClickHouse is an OLAP database optimized for high-performance analytics:
 
-## Scalability
+- Stores usage metrics and events
+- Supports real-time analytics queries
+- Enables fast aggregation for billing calculations
+- Provides data for usage dashboards and reporting
 
-The architecture scales by adding capacity, not by rewriting code.
+#### Kafka
 
-- **Decoupled services** — ingestion, processing, billing, and analytics are separate tiers connected by Kafka and Temporal. Each scales independently against its own workload.
-- **Stateless application tier** — API and worker services hold no local state, so scaling out is as simple as adding replicas.
-- **Stream-based ingestion** — Kafka smooths spikes and lets the consumer tier process at a sustainable rate without backpressure on your application.
-- **Analytics built for volume** — ClickHouse is engineered for high-cardinality, high-throughput usage data, so metering performance holds as your event volume grows.
+Kafka serves as the message broker and event streaming platform:
 
-## Security
+- Decouples services for async processing
+- Enables event-driven architecture
+- Ensures reliable delivery of events between services
+- Provides buffering during traffic spikes
 
-Security is layered from the network edge down to individual queries.
+#### Temporal
 
-| Layer | Control |
-|---|---|
-| **Network** | Isolated VPC per region; databases in private subnets with no public route; internal-only load balancers for data services |
-| **Transport** | TLS/HTTPS for all client traffic |
-| **Storage** | Encryption at rest for databases and backups |
-| **Authentication** | API-key authentication on every request; keys are scoped and revocable |
-| **Tenant isolation** | Every entity is scoped to tenant + environment, enforced on every read and write |
-| **Access control** | Least-privilege IAM roles; protected/guarded critical infrastructure resources |
-| **Auditability** | Infrastructure and application changes are version-controlled and reviewed before they ship |
+Temporal is a workflow orchestration platform that manages complex, stateful processes:
 
-<Warning>
-  Treat your Flexprice API keys like passwords. Use server-side keys, never expose them in client-side code or public repositories, and rotate them if you suspect exposure.
-</Warning>
+- Coordinates long-running business processes
+- Provides durability and reliability for mission-critical workflows
+- Manages scheduled jobs via cron-like functionality
+- Handles retries and error recovery automatically
 
-## Operations & Observability
+## Functional Building Blocks
 
-A mature platform is one you can reason about and recover.
+Flexprice is architected as a set of composable building blocks, each handling specific aspects of usage-based billing and subscription management. These blocks can be used independently or together, providing flexibility in how the platform is deployed and utilized.
 
-- **Infrastructure as code** — the entire platform is defined in Terraform/Terragrunt and Kubernetes manifests. Environments are reproducible and there are no undocumented, hand-built servers.
-- **GitOps delivery** — changes are applied through Argo CD from version control, giving a complete, auditable history of what is running and why.
-- **Monitoring** — services are instrumented and observed through Grafana and error-tracking tooling, so we detect and respond to issues quickly.
-- **Documented runbooks** — recovery procedures (restore from snapshot, scaling, upgrades) are written down and rehearsed, not improvised during an incident.
+#### Usage Metering Layer
 
-## Want Full Control? Self-Host.
+**Core Functionality:**
 
-Flexprice is open source. If your requirements call for running the platform inside your own cloud account or on-premises, you can deploy the exact same architecture yourself.
+- Collection and processing of usage events
+- Real-time event ingestion
+- Usage analytics and reporting
 
-<CardGroup cols={2}>
-  <Card title="Self-Hosting Guide" icon="book" href="/docs/getting-started/self-hosting-guide">
-    Run the full Flexprice stack with Docker Compose.
-  </Card>
-  <Card title="Self-Hosting on AWS" icon="aws" href="/docs/getting-started/self-hosting-aws">
-    A production reference deployment on AWS.
-  </Card>
-</CardGroup>
+**Interactions:**
 
-## Talk to Us
+- Provides usage data to the Pricing Layer for cost calculations
+- Feeds data to the Subscription Layer for usage-based billing
+- Supports the Entitlement Layer with metering for feature limits
 
-We're happy to go deeper — network diagrams, data handling, incident process, or a vendor security questionnaire. Reach the team at [support@flexprice.io](mailto:support@flexprice.io).
+```mermaid
+graph TB
+    classDef functional fill:#f0e68c,stroke:#8b8b00
+    classDef infrastructure fill:#fffacd,stroke:#daa520
+    classDef external fill:#f5f5f5,stroke:#888888
+
+    client["Client App"]:::external
+    metrics["Usage Metering Layer"]:::functional
+    clickhouse[(ClickHouse)]:::infrastructure
+    pricing["Pricing Layer"]:::functional
+    subscription["Subscription Layer"]:::functional
+
+    client -- "Send Events" --> metrics
+    metrics -- "Store Data" --> clickhouse
+    metrics -- "Usage Data" --> pricing
+    metrics -- "Usage Data" --> subscription
+```
+
+#### Pricing Layer
+
+**Core Functionality:**
+
+- Defines flexible pricing models
+- Supports various pricing strategies (tiered, volume, graduated, etc.)
+- Handles price calculations based on usage
+
+**Interactions:**
+
+- Works with Usage Metrics to calculate costs
+- Feeds into Subscription & Billing for invoice generation
+- Can be configured differently per subscription
+
+```mermaid
+graph TB
+    classDef functional fill:#f0e68c,stroke:#8b8b00
+    classDef infrastructure fill:#fffacd,stroke:#daa520
+
+    metrics["Usage Metering Layer"]:::functional
+    pricing["Pricing Layer"]:::functional
+    subscription["Subscription & Billing"]:::functional
+    postgres[(PostgreSQL)]:::infrastructure
+
+    metrics -- "Usage Data" --> pricing
+    pricing -- "Store Models" --> postgres
+    pricing -- "Cost Calculation" --> subscription
+```
+
+#### Subscription & Billing Layer
+
+**Core Functionality:**
+
+- Manages subscription lifecycle
+- Handles recurring and usage-based billing
+- Processes invoices and payments
+- Manages customer accounts and balances
+
+**Interactions:**
+
+- Uses Pricing Layer to determine charges
+- Leverages Entitlement Layer to provision appropriate access
+- Coordinates with Usage Metrics for consumption-based billing
+- Utilizes Temporal for scheduled operations like billing cycles
+
+```mermaid
+graph TB
+    classDef functional fill:#f0e68c,stroke:#8b8b00
+    classDef services fill:#e6e6fa,stroke:#9370db
+    classDef infrastructure fill:#fffacd,stroke:#daa520
+
+    subscription["Subscription & Billing"]:::functional
+    pricing["Pricing Layer"]:::functional
+    entitlement["Entitlement Layer"]:::functional
+    metrics["Usage Metrics"]:::functional
+    temporal[Temporal]:::infrastructure
+    postgres[(PostgreSQL)]:::infrastructure
+
+    pricing -- "Pricing Data" --> subscription
+    metrics -- "Usage Data" --> subscription
+    subscription -- "Store Data" --> postgres
+    subscription -- "Provision Access" --> entitlement
+    temporal -- "Scheduled Billing" --> subscription
+```
+
+#### Feature & Entitlement Layer
+
+**Core Functionality:**
+
+- Controls access to features
+- Enforces usage limits and quotas
+- Provides feature flagging capabilities
+- Manages customer entitlements
+
+**Interactions:**
+
+- References Subscription data to determine entitlements
+- Uses Usage Metrics to enforce limits
+- Can be queried by client applications for access control
+
+```mermaid
+graph TB
+    classDef functional fill:#f0e68c,stroke:#8b8b00
+    classDef infrastructure fill:#fffacd,stroke:#daa520
+    classDef external fill:#f5f5f5,stroke:#888888
+
+    client["Client App"]:::external
+    entitlement["Feature & Entitlement Layer"]:::functional
+    subscription["Subscription Layer"]:::functional
+    metrics["Usage Metrics"]:::functional
+    postgres[(PostgreSQL)]:::infrastructure
+
+    client -- "Access Check" --> entitlement
+    subscription -- "Entitlement Data" --> entitlement
+    metrics -- "Usage Limits" --> entitlement
+    entitlement -- "Store Configuration" --> postgres
+    entitlement -- "Access Control" --> client
+```


### PR DESCRIPTION
## Summary

Adds `.claude/skills/docs-writing/SKILL.md` — a Claude Code skill for writing, extending, and validating Flexprice documentation pages.

## What the skill covers

- **Repo layout** — where to put new files, what each directory is for
- **Mintlify MDX components** — `<Note>`, `<Warning>`, `<Check>`, `<Steps>`, `<CodeGroup>`, `<Frame>`, `<Card>`, tables, code blocks
- **Webhook payload patterns** — how to document webhook events consistently, anchored to existing alert docs
- **`docs.json` navigation** — rules for adding pages and sub-groups to the sidebar
- **Validation commands** — `mint broken-links` and `mint validate` with the Node 22 workaround required on this machine
- **Dev server setup** — how to run `mint dev` locally via the `.claude/launch.json` config
- **Editorial voice** — tone, tense, what to avoid
- **Pre-PR checklist** — everything to verify before opening a PR
- **Known pre-existing issues** — broken image links and Callout.tsx warning to ignore

## Why

Built from the process used to write the Alerts and Notifications doc (PR #186), so the skill encodes the exact workflow and environment quirks needed to ship docs reliably.

## Test plan

- [ ] Run `/docs` skill in a new Claude Code session in this repo and confirm it loads
- [ ] Confirm validation commands work as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)